### PR TITLE
Aero model abstraction

### DIFF
--- a/Assets/Particles/FX_Explosion_Rubble.prefab
+++ b/Assets/Particles/FX_Explosion_Rubble.prefab
@@ -25,12 +25,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 100702}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 402300}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!198 &19810594
 ParticleSystem:
@@ -39,19 +40,19 @@ ParticleSystem:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 100702}
-  serializedVersion: 6
+  serializedVersion: 8
   lengthInSec: 1
   simulationSpeed: 1
   stopAction: 0
   cullingMode: 3
   ringBufferMode: 0
   ringBufferLoopRange: {x: 0, y: 1}
+  emitterVelocityMode: 1
   looping: 0
   prewarm: 0
   playOnAwake: 1
   useUnscaledTime: 0
   autoRandomSeed: 1
-  useRigidbodyForVelocity: 1
   startDelay:
     serializedVersion: 2
     minMaxState: 0
@@ -232,6 +233,7 @@ ParticleSystem:
         atime6: 0
         atime7: 0
         m_Mode: 0
+        m_ColorSpace: -1
         m_NumColorKeys: 2
         m_NumAlphaKeys: 2
       minGradient:
@@ -261,6 +263,7 @@ ParticleSystem:
         atime6: 0
         atime7: 0
         m_Mode: 0
+        m_ColorSpace: -1
         m_NumColorKeys: 2
         m_NumAlphaKeys: 2
     startSize:
@@ -564,7 +567,9 @@ ParticleSystem:
         m_PostInfinity: 2
         m_RotationOrder: 4
     randomizeRotationDirection: 0
+    gravitySource: 0
     maxNumParticles: 500
+    customEmitterVelocity: {x: 0, y: 0, z: 0}
     size3D: 0
     rotation3D: 0
     gravityModifier:
@@ -1359,6 +1364,7 @@ ParticleSystem:
         atime6: 0
         atime7: 0
         m_Mode: 0
+        m_ColorSpace: -1
         m_NumColorKeys: 2
         m_NumAlphaKeys: 2
       minGradient:
@@ -1388,9 +1394,11 @@ ParticleSystem:
         atime6: 0
         atime7: 0
         m_Mode: 0
+        m_ColorSpace: -1
         m_NumColorKeys: 2
         m_NumAlphaKeys: 2
   UVModule:
+    serializedVersion: 2
     enabled: 0
     mode: 0
     timeMode: 0
@@ -1508,7 +1516,7 @@ ParticleSystem:
     rowIndex: 0
     cycles: 1
     uvChannelMask: -1
-    randomRow: 1
+    rowMode: 1
     sprites:
     - sprite: {fileID: 0}
     flipU: 0
@@ -2146,6 +2154,62 @@ ParticleSystem:
         m_PreInfinity: 2
         m_PostInfinity: 2
         m_RotationOrder: 4
+  LifetimeByEmitterSpeedModule:
+    enabled: 0
+    m_Curve:
+      serializedVersion: 2
+      minMaxState: 1
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: -0.8
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0.2
+          inSlope: -0.8
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    m_Range: {x: 0, y: 1}
   ForceModule:
     enabled: 0
     x:
@@ -2256,8 +2320,61 @@ ParticleSystem:
     inWorldSpace: 0
     randomizePerFrame: 0
   ExternalForcesModule:
+    serializedVersion: 2
     enabled: 0
-    multiplier: 1
+    multiplierCurve:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
     influenceFilter: 0
     influenceMask:
       serializedVersion: 2
@@ -3444,6 +3561,7 @@ ParticleSystem:
         atime6: 0
         atime7: 0
         m_Mode: 0
+        m_ColorSpace: -1
         m_NumColorKeys: 2
         m_NumAlphaKeys: 2
       minGradient:
@@ -3473,24 +3591,26 @@ ParticleSystem:
         atime6: 0
         atime7: 0
         m_Mode: 0
+        m_ColorSpace: -1
         m_NumColorKeys: 2
         m_NumAlphaKeys: 2
     range: {x: 0, y: 1}
   CollisionModule:
     enabled: 0
-    serializedVersion: 3
+    serializedVersion: 4
     type: 0
     collisionMode: 0
     colliderForce: 0
     multiplyColliderForceByParticleSize: 0
     multiplyColliderForceByParticleSpeed: 0
     multiplyColliderForceByCollisionAngle: 1
-    plane0: {fileID: 0}
-    plane1: {fileID: 0}
-    plane2: {fileID: 0}
-    plane3: {fileID: 0}
-    plane4: {fileID: 0}
-    plane5: {fileID: 0}
+    m_Planes:
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
     m_Dampen:
       serializedVersion: 2
       minMaxState: 0
@@ -3664,17 +3784,20 @@ ParticleSystem:
     interiorCollisions: 0
   TriggerModule:
     enabled: 0
-    collisionShape0: {fileID: 0}
-    collisionShape1: {fileID: 0}
-    collisionShape2: {fileID: 0}
-    collisionShape3: {fileID: 0}
-    collisionShape4: {fileID: 0}
-    collisionShape5: {fileID: 0}
+    serializedVersion: 2
     inside: 1
     outside: 0
     enter: 0
     exit: 0
+    colliderQueryMode: 0
     radiusScale: 1
+    primitives:
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
   SubModule:
     serializedVersion: 2
     enabled: 0
@@ -3858,6 +3981,7 @@ ParticleSystem:
         m_RotationOrder: 4
     minVertexDistance: 0.2
     textureMode: 0
+    textureScale: {x: 1, y: 1}
     ribbonCount: 1
     shadowBias: 0.5
     worldSpace: 0
@@ -3900,6 +4024,7 @@ ParticleSystem:
         atime6: 0
         atime7: 0
         m_Mode: 0
+        m_ColorSpace: -1
         m_NumColorKeys: 2
         m_NumAlphaKeys: 2
       minGradient:
@@ -3929,6 +4054,7 @@ ParticleSystem:
         atime6: 0
         atime7: 0
         m_Mode: 0
+        m_ColorSpace: -1
         m_NumColorKeys: 2
         m_NumAlphaKeys: 2
     widthOverTrail:
@@ -4016,6 +4142,7 @@ ParticleSystem:
         atime6: 0
         atime7: 0
         m_Mode: 0
+        m_ColorSpace: -1
         m_NumColorKeys: 2
         m_NumAlphaKeys: 2
       minGradient:
@@ -4045,6 +4172,7 @@ ParticleSystem:
         atime6: 0
         atime7: 0
         m_Mode: 0
+        m_ColorSpace: -1
         m_NumColorKeys: 2
         m_NumAlphaKeys: 2
   CustomDataModule:
@@ -4083,6 +4211,7 @@ ParticleSystem:
         atime6: 0
         atime7: 0
         m_Mode: 0
+        m_ColorSpace: -1
         m_NumColorKeys: 2
         m_NumAlphaKeys: 2
       minGradient:
@@ -4112,6 +4241,7 @@ ParticleSystem:
         atime6: 0
         atime7: 0
         m_Mode: 0
+        m_ColorSpace: -1
         m_NumColorKeys: 2
         m_NumAlphaKeys: 2
     colorLabel0: Color
@@ -4365,6 +4495,7 @@ ParticleSystem:
         atime6: 0
         atime7: 0
         m_Mode: 0
+        m_ColorSpace: -1
         m_NumColorKeys: 2
         m_NumAlphaKeys: 2
       minGradient:
@@ -4394,6 +4525,7 @@ ParticleSystem:
         atime6: 0
         atime7: 0
         m_Mode: 0
+        m_ColorSpace: -1
         m_NumColorKeys: 2
         m_NumAlphaKeys: 2
     colorLabel1: Color
@@ -4616,7 +4748,7 @@ ParticleSystem:
 --- !u!199 &19902532
 ParticleSystemRenderer:
   serializedVersion: 6
-  m_ObjectHideFlags: 2
+  m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
@@ -4625,9 +4757,15 @@ ParticleSystemRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -4640,6 +4778,7 @@ ParticleSystemRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -4653,6 +4792,7 @@ ParticleSystemRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_RenderMode: 4
+  m_MeshDistribution: 0
   m_SortMode: 0
   m_MinParticleSize: 0
   m_MaxParticleSize: 0.8
@@ -4665,15 +4805,23 @@ ParticleSystemRenderer:
   m_RenderAlignment: 2
   m_Pivot: {x: 0, y: 0, z: 0}
   m_Flip: {x: 0, y: 0, z: 0}
-  m_UseCustomVertexStreams: 0
   m_EnableGPUInstancing: 0
   m_ApplyActiveColorSpace: 0
   m_AllowRoll: 1
+  m_FreeformStretching: 0
+  m_RotateWithStretchDirection: 1
+  m_UseCustomVertexStreams: 0
   m_VertexStreams: 0001030405
+  m_UseCustomTrailVertexStreams: 0
+  m_TrailVertexStreams: 00010304
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
   m_Mesh1: {fileID: 0}
   m_Mesh2: {fileID: 0}
   m_Mesh3: {fileID: 0}
+  m_MeshWeighting: 1
+  m_MeshWeighting1: 1
+  m_MeshWeighting2: 1
+  m_MeshWeighting3: 1
   m_MaskInteraction: 0
 --- !u!1 &189566
 GameObject:
@@ -4700,12 +4848,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 189566}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 402300}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!198 &19877906
 ParticleSystem:
@@ -4714,19 +4863,19 @@ ParticleSystem:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 189566}
-  serializedVersion: 6
+  serializedVersion: 8
   lengthInSec: 0.1
   simulationSpeed: 1
   stopAction: 0
   cullingMode: 3
   ringBufferMode: 0
   ringBufferLoopRange: {x: 0, y: 1}
+  emitterVelocityMode: 1
   looping: 0
   prewarm: 0
   playOnAwake: 1
   useUnscaledTime: 0
   autoRandomSeed: 1
-  useRigidbodyForVelocity: 1
   startDelay:
     serializedVersion: 2
     minMaxState: 0
@@ -4907,6 +5056,7 @@ ParticleSystem:
         atime6: 0
         atime7: 0
         m_Mode: 0
+        m_ColorSpace: -1
         m_NumColorKeys: 2
         m_NumAlphaKeys: 2
       minGradient:
@@ -4936,6 +5086,7 @@ ParticleSystem:
         atime6: 0
         atime7: 0
         m_Mode: 0
+        m_ColorSpace: -1
         m_NumColorKeys: 2
         m_NumAlphaKeys: 2
     startSize:
@@ -5257,7 +5408,9 @@ ParticleSystem:
         m_PostInfinity: 2
         m_RotationOrder: 4
     randomizeRotationDirection: 0
+    gravitySource: 0
     maxNumParticles: 500
+    customEmitterVelocity: {x: 0, y: 0, z: 0}
     size3D: 0
     rotation3D: 0
     gravityModifier:
@@ -6052,6 +6205,7 @@ ParticleSystem:
         atime6: 0
         atime7: 0
         m_Mode: 0
+        m_ColorSpace: -1
         m_NumColorKeys: 4
         m_NumAlphaKeys: 2
       minGradient:
@@ -6081,9 +6235,11 @@ ParticleSystem:
         atime6: 0
         atime7: 0
         m_Mode: 0
+        m_ColorSpace: -1
         m_NumColorKeys: 2
         m_NumAlphaKeys: 2
   UVModule:
+    serializedVersion: 2
     enabled: 0
     mode: 0
     timeMode: 0
@@ -6201,7 +6357,7 @@ ParticleSystem:
     rowIndex: 0
     cycles: 1
     uvChannelMask: -1
-    randomRow: 1
+    rowMode: 1
     sprites:
     - sprite: {fileID: 0}
     flipU: 0
@@ -6839,6 +6995,62 @@ ParticleSystem:
         m_PreInfinity: 2
         m_PostInfinity: 2
         m_RotationOrder: 4
+  LifetimeByEmitterSpeedModule:
+    enabled: 0
+    m_Curve:
+      serializedVersion: 2
+      minMaxState: 1
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: -0.8
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0.2
+          inSlope: -0.8
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    m_Range: {x: 0, y: 1}
   ForceModule:
     enabled: 0
     x:
@@ -6949,8 +7161,61 @@ ParticleSystem:
     inWorldSpace: 0
     randomizePerFrame: 0
   ExternalForcesModule:
+    serializedVersion: 2
     enabled: 0
-    multiplier: 1
+    multiplierCurve:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
     influenceFilter: 0
     influenceMask:
       serializedVersion: 2
@@ -8128,6 +8393,7 @@ ParticleSystem:
         atime6: 0
         atime7: 0
         m_Mode: 0
+        m_ColorSpace: -1
         m_NumColorKeys: 2
         m_NumAlphaKeys: 2
       minGradient:
@@ -8157,24 +8423,26 @@ ParticleSystem:
         atime6: 0
         atime7: 0
         m_Mode: 0
+        m_ColorSpace: -1
         m_NumColorKeys: 2
         m_NumAlphaKeys: 2
     range: {x: 0, y: 1}
   CollisionModule:
     enabled: 0
-    serializedVersion: 3
+    serializedVersion: 4
     type: 0
     collisionMode: 0
     colliderForce: 0
     multiplyColliderForceByParticleSize: 0
     multiplyColliderForceByParticleSpeed: 0
     multiplyColliderForceByCollisionAngle: 1
-    plane0: {fileID: 0}
-    plane1: {fileID: 0}
-    plane2: {fileID: 0}
-    plane3: {fileID: 0}
-    plane4: {fileID: 0}
-    plane5: {fileID: 0}
+    m_Planes:
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
     m_Dampen:
       serializedVersion: 2
       minMaxState: 0
@@ -8348,17 +8616,20 @@ ParticleSystem:
     interiorCollisions: 0
   TriggerModule:
     enabled: 0
-    collisionShape0: {fileID: 0}
-    collisionShape1: {fileID: 0}
-    collisionShape2: {fileID: 0}
-    collisionShape3: {fileID: 0}
-    collisionShape4: {fileID: 0}
-    collisionShape5: {fileID: 0}
+    serializedVersion: 2
     inside: 1
     outside: 0
     enter: 0
     exit: 0
+    colliderQueryMode: 0
     radiusScale: 1
+    primitives:
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
   SubModule:
     serializedVersion: 2
     enabled: 0
@@ -8542,6 +8813,7 @@ ParticleSystem:
         m_RotationOrder: 4
     minVertexDistance: 0.2
     textureMode: 0
+    textureScale: {x: 1, y: 1}
     ribbonCount: 1
     shadowBias: 0.5
     worldSpace: 0
@@ -8584,6 +8856,7 @@ ParticleSystem:
         atime6: 0
         atime7: 0
         m_Mode: 0
+        m_ColorSpace: -1
         m_NumColorKeys: 2
         m_NumAlphaKeys: 2
       minGradient:
@@ -8613,6 +8886,7 @@ ParticleSystem:
         atime6: 0
         atime7: 0
         m_Mode: 0
+        m_ColorSpace: -1
         m_NumColorKeys: 2
         m_NumAlphaKeys: 2
     widthOverTrail:
@@ -8700,6 +8974,7 @@ ParticleSystem:
         atime6: 0
         atime7: 0
         m_Mode: 0
+        m_ColorSpace: -1
         m_NumColorKeys: 2
         m_NumAlphaKeys: 2
       minGradient:
@@ -8729,6 +9004,7 @@ ParticleSystem:
         atime6: 0
         atime7: 0
         m_Mode: 0
+        m_ColorSpace: -1
         m_NumColorKeys: 2
         m_NumAlphaKeys: 2
   CustomDataModule:
@@ -8767,6 +9043,7 @@ ParticleSystem:
         atime6: 0
         atime7: 0
         m_Mode: 0
+        m_ColorSpace: -1
         m_NumColorKeys: 2
         m_NumAlphaKeys: 2
       minGradient:
@@ -8796,6 +9073,7 @@ ParticleSystem:
         atime6: 0
         atime7: 0
         m_Mode: 0
+        m_ColorSpace: -1
         m_NumColorKeys: 2
         m_NumAlphaKeys: 2
     colorLabel0: Color
@@ -9049,6 +9327,7 @@ ParticleSystem:
         atime6: 0
         atime7: 0
         m_Mode: 0
+        m_ColorSpace: -1
         m_NumColorKeys: 2
         m_NumAlphaKeys: 2
       minGradient:
@@ -9078,6 +9357,7 @@ ParticleSystem:
         atime6: 0
         atime7: 0
         m_Mode: 0
+        m_ColorSpace: -1
         m_NumColorKeys: 2
         m_NumAlphaKeys: 2
     colorLabel1: Color
@@ -9300,7 +9580,7 @@ ParticleSystem:
 --- !u!199 &19926198
 ParticleSystemRenderer:
   serializedVersion: 6
-  m_ObjectHideFlags: 2
+  m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
@@ -9309,9 +9589,15 @@ ParticleSystemRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -9324,6 +9610,7 @@ ParticleSystemRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -9337,6 +9624,7 @@ ParticleSystemRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_RenderMode: 4
+  m_MeshDistribution: 0
   m_SortMode: 0
   m_MinParticleSize: 0
   m_MaxParticleSize: 0.8
@@ -9349,15 +9637,23 @@ ParticleSystemRenderer:
   m_RenderAlignment: 2
   m_Pivot: {x: 0, y: 0, z: 0}
   m_Flip: {x: 0, y: 0, z: 0}
-  m_UseCustomVertexStreams: 0
   m_EnableGPUInstancing: 0
   m_ApplyActiveColorSpace: 0
   m_AllowRoll: 1
+  m_FreeformStretching: 0
+  m_RotateWithStretchDirection: 1
+  m_UseCustomVertexStreams: 0
   m_VertexStreams: 0001030405
+  m_UseCustomTrailVertexStreams: 0
+  m_TrailVertexStreams: 00010304
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
   m_Mesh1: {fileID: 0}
   m_Mesh2: {fileID: 0}
   m_Mesh3: {fileID: 0}
+  m_MeshWeighting: 1
+  m_MeshWeighting1: 1
+  m_MeshWeighting2: 1
+  m_MeshWeighting3: 1
   m_MaskInteraction: 0
 --- !u!1 &191186
 GameObject:
@@ -9384,14 +9680,15 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 191186}
+  serializedVersion: 2
   m_LocalRotation: {x: -0.7008359, y: 0, z: 0, w: 0.7133226}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 462712}
   - {fileID: 452148}
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!198 &19821056
 ParticleSystem:
@@ -9400,19 +9697,19 @@ ParticleSystem:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 191186}
-  serializedVersion: 6
+  serializedVersion: 8
   lengthInSec: 0.1
   simulationSpeed: 1
   stopAction: 0
   cullingMode: 3
   ringBufferMode: 0
   ringBufferLoopRange: {x: 0, y: 1}
+  emitterVelocityMode: 1
   looping: 0
   prewarm: 0
   playOnAwake: 1
   useUnscaledTime: 0
   autoRandomSeed: 1
-  useRigidbodyForVelocity: 1
   startDelay:
     serializedVersion: 2
     minMaxState: 0
@@ -9575,6 +9872,7 @@ ParticleSystem:
         atime6: 0
         atime7: 0
         m_Mode: 0
+        m_ColorSpace: -1
         m_NumColorKeys: 2
         m_NumAlphaKeys: 2
       minGradient:
@@ -9604,6 +9902,7 @@ ParticleSystem:
         atime6: 0
         atime7: 0
         m_Mode: 0
+        m_ColorSpace: -1
         m_NumColorKeys: 2
         m_NumAlphaKeys: 2
     startSize:
@@ -9643,7 +9942,7 @@ ParticleSystem:
         m_RotationOrder: 4
     startSizeY:
       serializedVersion: 2
-      minMaxState: 0
+      minMaxState: 3
       scalar: 1
       minScalar: 1
       maxCurve:
@@ -9696,7 +9995,7 @@ ParticleSystem:
         m_RotationOrder: 4
     startSizeZ:
       serializedVersion: 2
-      minMaxState: 0
+      minMaxState: 3
       scalar: 1
       minScalar: 1
       maxCurve:
@@ -9907,7 +10206,9 @@ ParticleSystem:
         m_PostInfinity: 2
         m_RotationOrder: 4
     randomizeRotationDirection: 0
+    gravitySource: 0
     maxNumParticles: 40
+    customEmitterVelocity: {x: 0, y: 0, z: 0}
     size3D: 0
     rotation3D: 0
     gravityModifier:
@@ -10675,6 +10976,7 @@ ParticleSystem:
         atime6: 0
         atime7: 0
         m_Mode: 0
+        m_ColorSpace: -1
         m_NumColorKeys: 4
         m_NumAlphaKeys: 2
       minGradient:
@@ -10704,9 +11006,11 @@ ParticleSystem:
         atime6: 0
         atime7: 0
         m_Mode: 0
+        m_ColorSpace: -1
         m_NumColorKeys: 2
         m_NumAlphaKeys: 2
   UVModule:
+    serializedVersion: 2
     enabled: 0
     mode: 0
     timeMode: 0
@@ -10824,7 +11128,7 @@ ParticleSystem:
     rowIndex: 0
     cycles: 1
     uvChannelMask: -1
-    randomRow: 1
+    rowMode: 1
     sprites:
     - sprite: {fileID: 0}
     flipU: 0
@@ -11462,6 +11766,62 @@ ParticleSystem:
         m_PreInfinity: 2
         m_PostInfinity: 2
         m_RotationOrder: 4
+  LifetimeByEmitterSpeedModule:
+    enabled: 0
+    m_Curve:
+      serializedVersion: 2
+      minMaxState: 1
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: -0.8
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0.2
+          inSlope: -0.8
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+    m_Range: {x: 0, y: 1}
   ForceModule:
     enabled: 0
     x:
@@ -11572,8 +11932,61 @@ ParticleSystem:
     inWorldSpace: 0
     randomizePerFrame: 0
   ExternalForcesModule:
+    serializedVersion: 2
     enabled: 0
-    multiplier: 1
+    multiplierCurve:
+      serializedVersion: 2
+      minMaxState: 0
+      scalar: 1
+      minScalar: 1
+      maxCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      minCurve:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 1
+          inSlope: 0
+          outSlope: 0
+          tangentMode: 0
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0.33333334
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
     influenceFilter: 0
     influenceMask:
       serializedVersion: 2
@@ -12751,6 +13164,7 @@ ParticleSystem:
         atime6: 0
         atime7: 0
         m_Mode: 0
+        m_ColorSpace: -1
         m_NumColorKeys: 2
         m_NumAlphaKeys: 2
       minGradient:
@@ -12780,24 +13194,26 @@ ParticleSystem:
         atime6: 0
         atime7: 0
         m_Mode: 0
+        m_ColorSpace: -1
         m_NumColorKeys: 2
         m_NumAlphaKeys: 2
     range: {x: 0, y: 1}
   CollisionModule:
     enabled: 0
-    serializedVersion: 3
+    serializedVersion: 4
     type: 0
     collisionMode: 0
     colliderForce: 0
     multiplyColliderForceByParticleSize: 0
     multiplyColliderForceByParticleSpeed: 0
     multiplyColliderForceByCollisionAngle: 1
-    plane0: {fileID: 0}
-    plane1: {fileID: 0}
-    plane2: {fileID: 0}
-    plane3: {fileID: 0}
-    plane4: {fileID: 0}
-    plane5: {fileID: 0}
+    m_Planes:
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
     m_Dampen:
       serializedVersion: 2
       minMaxState: 0
@@ -12971,17 +13387,20 @@ ParticleSystem:
     interiorCollisions: 0
   TriggerModule:
     enabled: 0
-    collisionShape0: {fileID: 0}
-    collisionShape1: {fileID: 0}
-    collisionShape2: {fileID: 0}
-    collisionShape3: {fileID: 0}
-    collisionShape4: {fileID: 0}
-    collisionShape5: {fileID: 0}
+    serializedVersion: 2
     inside: 1
     outside: 0
     enter: 0
     exit: 0
+    colliderQueryMode: 0
     radiusScale: 1
+    primitives:
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
+    - {fileID: 0}
   SubModule:
     serializedVersion: 2
     enabled: 0
@@ -13165,6 +13584,7 @@ ParticleSystem:
         m_RotationOrder: 4
     minVertexDistance: 0.2
     textureMode: 0
+    textureScale: {x: 1, y: 1}
     ribbonCount: 1
     shadowBias: 0.5
     worldSpace: 0
@@ -13207,6 +13627,7 @@ ParticleSystem:
         atime6: 0
         atime7: 0
         m_Mode: 0
+        m_ColorSpace: -1
         m_NumColorKeys: 2
         m_NumAlphaKeys: 2
       minGradient:
@@ -13236,6 +13657,7 @@ ParticleSystem:
         atime6: 0
         atime7: 0
         m_Mode: 0
+        m_ColorSpace: -1
         m_NumColorKeys: 2
         m_NumAlphaKeys: 2
     widthOverTrail:
@@ -13323,6 +13745,7 @@ ParticleSystem:
         atime6: 0
         atime7: 0
         m_Mode: 0
+        m_ColorSpace: -1
         m_NumColorKeys: 2
         m_NumAlphaKeys: 2
       minGradient:
@@ -13352,6 +13775,7 @@ ParticleSystem:
         atime6: 0
         atime7: 0
         m_Mode: 0
+        m_ColorSpace: -1
         m_NumColorKeys: 2
         m_NumAlphaKeys: 2
   CustomDataModule:
@@ -13390,6 +13814,7 @@ ParticleSystem:
         atime6: 0
         atime7: 0
         m_Mode: 0
+        m_ColorSpace: -1
         m_NumColorKeys: 2
         m_NumAlphaKeys: 2
       minGradient:
@@ -13419,6 +13844,7 @@ ParticleSystem:
         atime6: 0
         atime7: 0
         m_Mode: 0
+        m_ColorSpace: -1
         m_NumColorKeys: 2
         m_NumAlphaKeys: 2
     colorLabel0: Color
@@ -13672,6 +14098,7 @@ ParticleSystem:
         atime6: 0
         atime7: 0
         m_Mode: 0
+        m_ColorSpace: -1
         m_NumColorKeys: 2
         m_NumAlphaKeys: 2
       minGradient:
@@ -13701,6 +14128,7 @@ ParticleSystem:
         atime6: 0
         atime7: 0
         m_Mode: 0
+        m_ColorSpace: -1
         m_NumColorKeys: 2
         m_NumAlphaKeys: 2
     colorLabel1: Color
@@ -13923,7 +14351,7 @@ ParticleSystem:
 --- !u!199 &19943340
 ParticleSystemRenderer:
   serializedVersion: 6
-  m_ObjectHideFlags: 2
+  m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
@@ -13932,9 +14360,15 @@ ParticleSystemRenderer:
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -13947,6 +14381,7 @@ ParticleSystemRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -13960,6 +14395,7 @@ ParticleSystemRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_RenderMode: 4
+  m_MeshDistribution: 0
   m_SortMode: 0
   m_MinParticleSize: 0
   m_MaxParticleSize: 0.8
@@ -13972,13 +14408,21 @@ ParticleSystemRenderer:
   m_RenderAlignment: 2
   m_Pivot: {x: 0, y: 0, z: 0}
   m_Flip: {x: 0, y: 0, z: 0}
-  m_UseCustomVertexStreams: 0
   m_EnableGPUInstancing: 0
   m_ApplyActiveColorSpace: 0
   m_AllowRoll: 1
+  m_FreeformStretching: 0
+  m_RotateWithStretchDirection: 1
+  m_UseCustomVertexStreams: 0
   m_VertexStreams: 0001030405
+  m_UseCustomTrailVertexStreams: 0
+  m_TrailVertexStreams: 00010304
   m_Mesh: {fileID: 4300002, guid: 42e0384be8104584cbcc3a1fadaafb79, type: 3}
   m_Mesh1: {fileID: 0}
   m_Mesh2: {fileID: 0}
   m_Mesh3: {fileID: 0}
+  m_MeshWeighting: 1
+  m_MeshWeighting1: 1
+  m_MeshWeighting2: 1
+  m_MeshWeighting3: 1
   m_MaskInteraction: 0

--- a/Assets/Prefabs/Missile.prefab
+++ b/Assets/Prefabs/Missile.prefab
@@ -562,7 +562,6 @@ GameObject:
   - component: {fileID: 1345124909}
   - component: {fileID: 5196629191105789684}
   - component: {fileID: 7391620925903998971}
-  - component: {fileID: 2549006460702943225}
   m_Layer: 0
   m_Name: Missile
   m_TagString: Missile
@@ -748,7 +747,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_missileCOM: {fileID: 9119472201120373816}
-  m_airSpeed: 100
+  m_launchSpeed: 100
   explosionParticle: {fileID: 3224380626908557825}
   explosionSound: {fileID: 8300000, guid: 4bcde6de2166e41e284ec46d8a01fb90, type: 3}
   thrustSound: {fileID: 8300000, guid: 113ee460fadc340e4957a7404a9fbb27, type: 3}
@@ -767,7 +766,8 @@ MonoBehaviour:
   m_wingArea: 1
   m_tailArea: 0.1
   m_maxDeflect: 10
-  m_tail2CMDistance: 0.5
+  m_tailToCMDistance: 2.5
+  m_velocity: {x: 0, y: 0, z: 0}
 --- !u!114 &7391620925903998971
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -782,22 +782,21 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_timeConstant: 0.8
   m_angleOfAttackLimit: 10
+  m_vertPIDController:
+    pGain: 1
+    iGain: 0.001
+    dGain: 0.2
+  m_horzPIDController:
+    pGain: 1
+    iGain: 0.001
+    dGain: 0.2
+  m_rollPIDController:
+    pGain: 0
+    iGain: 0
+    dGain: 0
+  <IsInPursuit>k__BackingField: 0
+  <NavGain>k__BackingField: 3
   <Tgo>k__BackingField: 0
---- !u!114 &2549006460702943225
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5916614425571799360}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 913dcc75e3898e847a342e194415a1ae, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  pGain: 1
-  iGain: 0.001
-  dGain: 0.2
 --- !u!1 &6099966194373675435
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Missile.prefab
+++ b/Assets/Prefabs/Missile.prefab
@@ -560,8 +560,8 @@ GameObject:
   - component: {fileID: 1345124912}
   - component: {fileID: 1345124915}
   - component: {fileID: 1345124909}
-  - component: {fileID: 5196629191105789684}
   - component: {fileID: 7391620925903998971}
+  - component: {fileID: 6540794104777580120}
   m_Layer: 0
   m_Name: Missile
   m_TagString: Missile
@@ -748,26 +748,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_missileCOM: {fileID: 9119472201120373816}
   m_launchSpeed: 100
-  explosionParticle: {fileID: 3224380626908557825}
-  explosionSound: {fileID: 8300000, guid: 4bcde6de2166e41e284ec46d8a01fb90, type: 3}
-  thrustSound: {fileID: 8300000, guid: 113ee460fadc340e4957a7404a9fbb27, type: 3}
---- !u!114 &5196629191105789684
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5916614425571799360}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2146adc2a5f17374d842b51d266d7ab4, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_wingArea: 1
-  m_tailArea: 0.1
-  m_maxDeflect: 10
-  m_tailToCMDistance: 2.5
-  m_velocity: {x: 0, y: 0, z: 0}
+  m_explosionParticle: {fileID: 3224380626908557825}
+  m_explosionSound: {fileID: 8300000, guid: 4bcde6de2166e41e284ec46d8a01fb90, type: 3}
+  m_thrustSound: {fileID: 8300000, guid: 113ee460fadc340e4957a7404a9fbb27, type: 3}
 --- !u!114 &7391620925903998971
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -781,22 +764,40 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_timeConstant: 0.8
-  m_angleOfAttackLimit: 10
+  m_angleOfAttackLimit_deg: 10
   m_vertPIDController:
-    pGain: 1
+    pGain: 6
     iGain: 0.001
-    dGain: 0.2
+    dGain: 0.5
   m_horzPIDController:
-    pGain: 1
+    pGain: 6
     iGain: 0.001
-    dGain: 0.2
+    dGain: 0.5
   m_rollPIDController:
-    pGain: 0
+    pGain: 0.1
     iGain: 0
     dGain: 0
   <IsInPursuit>k__BackingField: 0
   <NavGain>k__BackingField: 3
   <Tgo>k__BackingField: 0
+--- !u!114 &6540794104777580120
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5916614425571799360}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cd57d3d5be4a5a043ac7f54f0fc4f18c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_velocity: {x: 0, y: 0, z: 0}
+  m_finArea: 0.1
+  m_finMaxDeflect_deg: 40
+  m_tailToCMDistance: 2.5
+  m_missileRadius: 0.3
+  m_wingArea: 1
 --- !u!1 &6099966194373675435
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/MissileEvader.unity
+++ b/Assets/Scenes/MissileEvader.unity
@@ -13,7 +13,7 @@ OcclusionCullingSettings:
 --- !u!104 &2
 RenderSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 9
+  serializedVersion: 10
   m_Fog: 0
   m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
   m_FogMode: 3
@@ -38,13 +38,12 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.18028352, g: 0.22571376, b: 0.30692244, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 12
-  m_GIWorkflowMode: 1
+  serializedVersion: 13
+  m_BakeOnSceneLoad: 0
   m_GISettings:
     serializedVersion: 2
     m_BounceScale: 1
@@ -67,9 +66,6 @@ LightmapSettings:
     m_LightmapParameters: {fileID: 0}
     m_LightmapsBakeMode: 1
     m_TextureCompression: 1
-    m_FinalGather: 0
-    m_FinalGatherFiltering: 1
-    m_FinalGatherRayCount: 256
     m_ReflectionCompression: 2
     m_MixedBakeMode: 2
     m_BakeBackend: 1
@@ -97,14 +93,14 @@ LightmapSettings:
     m_ExportTrainingData: 0
     m_TrainingDataDestination: TrainingData
     m_LightProbeSampleCountMultiplier: 4
-  m_LightingDataAsset: {fileID: 0}
+  m_LightingDataAsset: {fileID: 20201, guid: 0000000000000000f000000000000000, type: 0}
   m_LightingSettings: {fileID: 0}
 --- !u!196 &4
 NavMeshSettings:
   serializedVersion: 2
   m_ObjectHideFlags: 0
   m_BuildSettings:
-    serializedVersion: 2
+    serializedVersion: 3
     agentTypeID: 0
     agentRadius: 0.5
     agentHeight: 2
@@ -117,7 +113,7 @@ NavMeshSettings:
     cellSize: 0.16666667
     manualTileSize: 0
     tileSize: 256
-    accuratePlacement: 0
+    buildHeightMesh: 0
     maxJobWorkers: 0
     preserveTilesOutsideBounds: 0
     debug:
@@ -151,9 +147,17 @@ MeshCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 204731142}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 0
+  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 4
+  serializedVersion: 5
   m_Convex: 1
   m_CookingOptions: 30
   m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
@@ -174,6 +178,9 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 2
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -214,13 +221,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 204731142}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1000, y: 1, z: 1000}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!54 &204731147
 Rigidbody:
@@ -229,10 +236,21 @@ Rigidbody:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 204731142}
-  serializedVersion: 2
+  serializedVersion: 5
   m_Mass: 1e+9
-  m_Drag: Infinity
-  m_AngularDrag: 0.05
+  m_LinearDamping: Infinity
+  m_AngularDamping: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
   m_UseGravity: 0
   m_IsKinematic: 0
   m_Interpolate: 0
@@ -270,9 +288,8 @@ Light:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 410087039}
   m_Enabled: 1
-  serializedVersion: 10
+  serializedVersion: 11
   m_Type: 1
-  m_Shape: 0
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_Intensity: 2
   m_Range: 10
@@ -322,8 +339,12 @@ Light:
   m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
   m_UseBoundingSphereOverride: 0
   m_UseViewFrustumForShadowCasterCull: 1
+  m_ForceVisible: 0
   m_ShadowRadius: 0
   m_ShadowAngle: 0
+  m_LightUnit: 1
+  m_LuxAtDistance: 1
+  m_EnableSpotReflector: 1
 --- !u!4 &410087041
 Transform:
   m_ObjectHideFlags: 0
@@ -331,13 +352,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 410087039}
+  serializedVersion: 2
   m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
   m_LocalPosition: {x: 0, y: 3, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
 --- !u!114 &410087042
 MonoBehaviour:
@@ -351,14 +372,17 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 474bcb49853aa07438625e644c072ee6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Version: 1
+  m_Version: 3
   m_UsePipelineSettings: 1
   m_AdditionalLightsShadowResolutionTier: 2
   m_LightLayerMask: 1
+  m_RenderingLayers: 1
   m_CustomShadowLayers: 0
   m_ShadowLayerMask: 1
+  m_ShadowRenderingLayers: 1
   m_LightCookieSize: {x: 1, y: 1}
   m_LightCookieOffset: {x: 0, y: 0}
+  m_SoftShadowQuality: 1
 --- !u!1 &485161966
 GameObject:
   m_ObjectHideFlags: 0
@@ -388,7 +412,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 430105d80b8bcf3409813653058d3ac7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  waveNumber: 3
+  waveNumber: 1
   spawnRadius: 800
   minSpawnRadius: 100
   missilePrefab: {fileID: 5916614425571799360, guid: 7bf30e91fa0bb604fa7f8eb699c3f7bc,
@@ -400,13 +424,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 485161966}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -480.04877, y: 1.8461108, z: 240.25223}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &493906115 stripped
 GameObject:
@@ -431,6 +455,7 @@ AudioSource:
   serializedVersion: 4
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 0}
+  m_Resource: {fileID: 0}
   m_PlayOnAwake: 1
   m_Volume: 1
   m_Pitch: 1
@@ -563,19 +588,20 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 832575517}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &4721762016015599833
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
+    serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
     - target: {fileID: 3802353106296654703, guid: 73fb3bf0d427ef44b8362f6470d5de2b,
@@ -674,4 +700,20 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 343477455}
     m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 4721762015432934139, guid: 73fb3bf0d427ef44b8362f6470d5de2b,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 531315387}
   m_SourcePrefab: {fileID: 100100000, guid: 73fb3bf0d427ef44b8362f6470d5de2b, type: 3}
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 410087041}
+  - {fileID: 832575519}
+  - {fileID: 4721762016015599833}
+  - {fileID: 204731146}
+  - {fileID: 485161968}

--- a/Assets/Scripts/AerodynamicsModel.cs
+++ b/Assets/Scripts/AerodynamicsModel.cs
@@ -1,18 +1,22 @@
+
 using System.Runtime.InteropServices.WindowsRuntime;
+using Unity.VisualScripting;
 using UnityEngine;
+using UnityEngine.Timeline;
 
 public class AerodynamicsModel : MonoBehaviour
 {
-
     private const float c_rho = 1.293f;
     [SerializeField]
     private float m_wingArea = 1f;
     [SerializeField]
-    private float m_tailArea = 0.1f;
+    private float m_finArea = 0.1f;
     [SerializeField]
-    private float m_maxDeflect = 10f;
+    private float m_finMaxDeflect_deg = 40f;
     [SerializeField]
-    private float m_tail2CMDistance = 0.5f;
+    private float m_tailToCMDistance = 2.5f;
+    [SerializeField]
+    private float m_missileRadius = 0.3f;
     private Rigidbody m_body;
     [SerializeField]
     private Vector3 m_velocity;
@@ -23,7 +27,7 @@ public class AerodynamicsModel : MonoBehaviour
             return 0.5f * c_rho * Mathf.Pow(m_velocity.magnitude, 2);
         }
     }
-
+    private Vector3 m_control;
     public float WingArea { get { return m_wingArea; } private set { m_wingArea = value; } }
 
     void Awake()
@@ -37,40 +41,67 @@ public class AerodynamicsModel : MonoBehaviour
         m_velocity = m_body.linearVelocity;
     }
 
-    public Vector3 GenerateAeroForces()
+    void FixedUpdate()
+    {
+
+        Vector3 torque_local = CalculateLocalAttitudeMoment(m_control);
+        Vector3 aeroForces = CalculateAeroForces();
+
+        m_body.AddForce(aeroForces);
+
+        if (torque_local.magnitude > 0.001)
+        {
+            m_body.AddRelativeTorque(torque_local);
+        }
+    }
+
+    public Vector3 CalculateAeroForces()
     {
         Vector3 body2velAngle = Vector3.Cross(m_body.transform.forward, m_velocity);
-        Vector3  lift_direction= Vector3.Cross(m_velocity, body2velAngle).normalized;
+        Vector3 liftDirection = Vector3.Cross(m_velocity, body2velAngle).normalized;
 
         float attackAngle = Vector3.Angle(m_body.transform.forward, m_velocity);
 
-        float lift_coefficient = 2f * Mathf.PI * attackAngle * Mathf.Deg2Rad;
-        float drag_coefficient = 1f * Mathf.Pow(attackAngle * Mathf.Deg2Rad, 2f);
+        float liftCoefficient = 2f * Mathf.PI * attackAngle * Mathf.Deg2Rad;
+        float dragCoefficient = 1f * Mathf.Pow(attackAngle * Mathf.Deg2Rad, 2f);
 
         if (attackAngle > 12) // Stalling condition
         {
-            lift_coefficient = Mathf.Sin(2f * attackAngle * Mathf.Deg2Rad);
-            drag_coefficient = 1f - Mathf.Cos(2f * attackAngle * Mathf.Deg2Rad);
+            liftCoefficient = Mathf.Sin(2f * attackAngle * Mathf.Deg2Rad);
+            dragCoefficient = 1f - Mathf.Cos(2f * attackAngle * Mathf.Deg2Rad);
         }
 
 
-        Vector3 lift_force = lift_direction * lift_coefficient * DynPressure * m_wingArea;
-        Vector3 drag_force = -m_velocity.normalized * drag_coefficient * DynPressure * m_wingArea;
+        Vector3 liftForce = liftDirection * liftCoefficient * DynPressure * m_wingArea;
+        Vector3 dragForce = -m_velocity.normalized * dragCoefficient * DynPressure * m_wingArea;
 
-        return lift_force + drag_force;
+        return liftForce + dragForce; // in world frame
     }
 
-    public Vector3 GenerateControlTorque(Vector3 control)
+    public Vector3 CalculateLocalAttitudeMoment(Vector3 attitudeControl)
     {
 
+        if (attitudeControl.magnitude > 1)
+        {
+            attitudeControl = attitudeControl.normalized;
+        }
 
-        float lift_coefficient = 2f * Mathf.PI * m_maxDeflect;
+        float liftCoefficient = 2f * Mathf.PI * m_finMaxDeflect_deg * Mathf.Deg2Rad; //* Mathf.Deg2Rad;
 
-        float max_torque = DynPressure * lift_coefficient * m_tailArea * m_tail2CMDistance;
-        Vector3 desired_torque = control * max_torque;
+        float maxTorque = 4 * DynPressure * liftCoefficient * m_finArea * m_tailToCMDistance;
+        float maxRollTorque = 4 * DynPressure * liftCoefficient * m_finArea * m_missileRadius;
+        Vector3 attitudeMoment_local = Vector3.zero;
+        attitudeMoment_local.x = attitudeControl.x * maxTorque;
+        attitudeMoment_local.y = attitudeControl.y * maxTorque;
+        attitudeMoment_local.z = attitudeControl.z * maxRollTorque;
 
-        return desired_torque;
+        return attitudeMoment_local; // in local frame
 
+    }
+
+    public void SetAttitudeControl(Vector3 control)
+    {
+        m_control = control; // Could add slew rates
     }
 
 }

--- a/Assets/Scripts/AerodynamicsModel.cs
+++ b/Assets/Scripts/AerodynamicsModel.cs
@@ -4,22 +4,13 @@ using Unity.VisualScripting;
 using UnityEngine;
 using UnityEngine.Timeline;
 
-public class AerodynamicsModel : MonoBehaviour
+abstract public class AerodynamicsModel : MonoBehaviour
 {
     private const float c_rho = 1.293f;
+
+    protected Rigidbody m_body;
     [SerializeField]
-    private float m_wingArea = 1f;
-    [SerializeField]
-    private float m_finArea = 0.1f;
-    [SerializeField]
-    private float m_finMaxDeflect_deg = 40f;
-    [SerializeField]
-    private float m_tailToCMDistance = 2.5f;
-    [SerializeField]
-    private float m_missileRadius = 0.3f;
-    private Rigidbody m_body;
-    [SerializeField]
-    private Vector3 m_velocity;
+    protected Vector3 m_velocity;
     public float DynPressure
     {
         get
@@ -27,8 +18,8 @@ public class AerodynamicsModel : MonoBehaviour
             return 0.5f * c_rho * Mathf.Pow(m_velocity.magnitude, 2);
         }
     }
-    private Vector3 m_control;
-    public float WingArea { get { return m_wingArea; } private set { m_wingArea = value; } }
+    protected Vector3 m_control;
+    public abstract float WingArea { get; }
 
     void Awake()
     {
@@ -55,7 +46,7 @@ public class AerodynamicsModel : MonoBehaviour
         }
     }
 
-    public Vector3 CalculateAeroForces()
+    virtual public Vector3 CalculateAeroForces()
     {
         Vector3 body2velAngle = Vector3.Cross(m_body.transform.forward, m_velocity);
         Vector3 liftDirection = Vector3.Cross(m_velocity, body2velAngle).normalized;
@@ -72,34 +63,15 @@ public class AerodynamicsModel : MonoBehaviour
         }
 
 
-        Vector3 liftForce = liftDirection * liftCoefficient * DynPressure * m_wingArea;
-        Vector3 dragForce = -m_velocity.normalized * dragCoefficient * DynPressure * m_wingArea;
+        Vector3 liftForce = liftDirection * liftCoefficient * DynPressure * WingArea;
+        Vector3 dragForce = -m_velocity.normalized * dragCoefficient * DynPressure * WingArea;
 
         return liftForce + dragForce; // in world frame
     }
 
-    public Vector3 CalculateLocalAttitudeMoment(Vector3 attitudeControl)
-    {
+    abstract public Vector3 CalculateLocalAttitudeMoment(Vector3 attitudeControl);
 
-        if (attitudeControl.magnitude > 1)
-        {
-            attitudeControl = attitudeControl.normalized;
-        }
-
-        float liftCoefficient = 2f * Mathf.PI * m_finMaxDeflect_deg * Mathf.Deg2Rad; //* Mathf.Deg2Rad;
-
-        float maxTorque = 4 * DynPressure * liftCoefficient * m_finArea * m_tailToCMDistance;
-        float maxRollTorque = 4 * DynPressure * liftCoefficient * m_finArea * m_missileRadius;
-        Vector3 attitudeMoment_local = Vector3.zero;
-        attitudeMoment_local.x = attitudeControl.x * maxTorque;
-        attitudeMoment_local.y = attitudeControl.y * maxTorque;
-        attitudeMoment_local.z = attitudeControl.z * maxRollTorque;
-
-        return attitudeMoment_local; // in local frame
-
-    }
-
-    public void SetAttitudeControl(Vector3 control)
+    virtual public void SetAttitudeControl(Vector3 control)
     {
         m_control = control; // Could add slew rates
     }

--- a/Assets/Scripts/AerodynamicsModel.cs
+++ b/Assets/Scripts/AerodynamicsModel.cs
@@ -11,6 +11,8 @@ abstract public class AerodynamicsModel : MonoBehaviour
     protected Rigidbody m_body;
     [SerializeField]
     protected Vector3 m_velocity;
+    [SerializeField]
+    protected float m_stallAoA = 12f;
     public float DynPressure
     {
         get
@@ -56,7 +58,7 @@ abstract public class AerodynamicsModel : MonoBehaviour
         float liftCoefficient = 2f * Mathf.PI * attackAngle * Mathf.Deg2Rad;
         float dragCoefficient = 1f * Mathf.Pow(attackAngle * Mathf.Deg2Rad, 2f);
 
-        if (attackAngle > 12) // Stalling condition
+        if (attackAngle > m_stallAoA) // Stalling condition
         {
             liftCoefficient = Mathf.Sin(2f * attackAngle * Mathf.Deg2Rad);
             dragCoefficient = 1f - Mathf.Cos(2f * attackAngle * Mathf.Deg2Rad);

--- a/Assets/Scripts/AerodynamicsModel.cs
+++ b/Assets/Scripts/AerodynamicsModel.cs
@@ -12,7 +12,8 @@ abstract public class AerodynamicsModel : MonoBehaviour
     [SerializeField]
     protected Vector3 m_velocity;
     [SerializeField]
-    protected float m_stallAoA = 12f;
+    protected float m_stallAoA_deg = 12f;
+    public float StallAoA_deg { get => m_stallAoA_deg; set => m_stallAoA_deg = value; }
     public float DynPressure
     {
         get
@@ -58,7 +59,7 @@ abstract public class AerodynamicsModel : MonoBehaviour
         float liftCoefficient = 2f * Mathf.PI * attackAngle * Mathf.Deg2Rad;
         float dragCoefficient = 1f * Mathf.Pow(attackAngle * Mathf.Deg2Rad, 2f);
 
-        if (attackAngle > m_stallAoA) // Stalling condition
+        if (attackAngle > m_stallAoA_deg) // Stalling condition
         {
             liftCoefficient = Mathf.Sin(2f * attackAngle * Mathf.Deg2Rad);
             dragCoefficient = 1f - Mathf.Cos(2f * attackAngle * Mathf.Deg2Rad);

--- a/Assets/Scripts/AerodynamicsModel.cs
+++ b/Assets/Scripts/AerodynamicsModel.cs
@@ -16,8 +16,14 @@ public class AerodynamicsModel : MonoBehaviour
     private Rigidbody m_body;
     [SerializeField]
     private Vector3 m_velocity;
-    private float m_dynPressure;
-    public float DynPressure { get { return m_dynPressure; } private set { m_dynPressure = value; } }
+    public float DynPressure
+    {
+        get
+        {
+            return 0.5f * c_rho * Mathf.Pow(m_velocity.magnitude, 2);
+        }
+    }
+
     public float WingArea { get { return m_wingArea; } private set { m_wingArea = value; } }
 
     void Awake()
@@ -29,7 +35,6 @@ public class AerodynamicsModel : MonoBehaviour
     void Update()
     {
         m_velocity = m_body.linearVelocity;
-        m_dynPressure = 0.5f * c_rho * Mathf.Pow(m_velocity.magnitude, 2);
     }
 
     public Vector3 GenerateAeroForces()
@@ -49,8 +54,8 @@ public class AerodynamicsModel : MonoBehaviour
         }
 
 
-        Vector3 lift_force = lift_direction * lift_coefficient * m_dynPressure * m_wingArea;
-        Vector3 drag_force = -m_velocity.normalized * drag_coefficient * m_dynPressure * m_wingArea;
+        Vector3 lift_force = lift_direction * lift_coefficient * DynPressure * m_wingArea;
+        Vector3 drag_force = -m_velocity.normalized * drag_coefficient * DynPressure * m_wingArea;
 
         return lift_force + drag_force;
     }
@@ -61,7 +66,7 @@ public class AerodynamicsModel : MonoBehaviour
 
         float lift_coefficient = 2f * Mathf.PI * m_maxDeflect;
 
-        float max_torque = m_dynPressure * lift_coefficient * m_tailArea * m_tail2CMDistance;
+        float max_torque = DynPressure * lift_coefficient * m_tailArea * m_tail2CMDistance;
         Vector3 desired_torque = control * max_torque;
 
         return desired_torque;

--- a/Assets/Scripts/AerodynamicsModel.cs.meta
+++ b/Assets/Scripts/AerodynamicsModel.cs.meta
@@ -1,2 +1,2 @@
 fileFormatVersion: 2
-guid: 2146adc2a5f17374d842b51d266d7ab4
+guid: 78bd63edc55ef624baf5d59aa358dac7

--- a/Assets/Scripts/AutoPilotController.cs
+++ b/Assets/Scripts/AutoPilotController.cs
@@ -45,9 +45,9 @@ public class AutoPilotController : MonoBehaviour
     void Awake()
     {
         //m_pidController = GetComponent<PIDController>();
-        m_vertPIDController = new PIDController(6f,0.001f,0.2f);
-        m_horzPIDController = new PIDController(6f,0.001f,0.2f);
-        m_rollPIDController = new PIDController(0.1f, 0, 0);
+        m_vertPIDController = new PIDController();
+        m_horzPIDController = new PIDController();
+        m_rollPIDController = new PIDController();
 
         m_AeroModel = GetComponent<AerodynamicsModel>();
         m_body = GetComponent<Rigidbody>();

--- a/Assets/Scripts/AutoPilotController.cs
+++ b/Assets/Scripts/AutoPilotController.cs
@@ -1,3 +1,4 @@
+
 using Unity.VisualScripting;
 using UnityEngine;
 
@@ -8,18 +9,25 @@ public class AutoPilotController : MonoBehaviour
     [SerializeField]
     private float m_timeConstant = 0.8f;
     [SerializeField]
-    private float m_angleOfAttackLimit = 10f; // degrees
-    private PIDController m_pidController;
+    private float m_angleOfAttackLimit_deg = 10f; // degrees
+    [Header("Vertical Pitch PID")]
+    [SerializeField] private PIDController m_vertPIDController;
+    [Header("Horizontal Pitch PID")]
+    [SerializeField] private PIDController m_horzPIDController;
+    [Header("Roll Pitch PID")]
+    [SerializeField] private PIDController m_rollPIDController;
     private AerodynamicsModel m_AeroModel;
     private Vector3 m_velocity;
     private Vector3 m_accelerationCmd;
     private Rigidbody m_body;
+    [field: SerializeField]
     public bool IsInPursuit { get; private set; } = false;
 
     //properties
     public Vector3 RelativePosition { get; private set; }
     public Vector3 RelativeVelocity { get; private set; }
-    public float Gain { get; set; } = 3f;
+    [field: SerializeField]
+    public float NavGain { get; set; } = 3f;
     [field: SerializeField]
     public float Tgo { get; private set; }
     public GameObject Target
@@ -36,7 +44,11 @@ public class AutoPilotController : MonoBehaviour
 
     void Awake()
     {
-        m_pidController = GetComponent<PIDController>();
+        //m_pidController = GetComponent<PIDController>();
+        m_vertPIDController = new PIDController(6f,0.001f,0.2f);
+        m_horzPIDController = new PIDController(6f,0.001f,0.2f);
+        m_rollPIDController = new PIDController(0.1f, 0, 0);
+
         m_AeroModel = GetComponent<AerodynamicsModel>();
         m_body = GetComponent<Rigidbody>();
     }
@@ -55,57 +67,70 @@ public class AutoPilotController : MonoBehaviour
         // determine acceleration command Strategy
         if (IsInPursuit)
         {
-            m_accelerationCmd = PursuitCommand();
+            m_accelerationCmd = CommandPursuit();
         }
         else
         {
-            m_accelerationCmd = GravityTurnCommand();
+            m_accelerationCmd = CommandGravityTurn();
         }
 
         // Leave gravity turn when we are stable
-        if (!IsInPursuit && (m_accelerationCmd.normalized.y > 0 || m_accelerationCmd.normalized.y < -0.99f))
+        if (!IsInPursuit && (m_accelerationCmd.normalized.y > 0 || m_accelerationCmd.normalized.y < -0.95f))
         {
             IsInPursuit = true;
         }
 
     }
 
-    public Vector3 GetControl()
+    public Vector3 ComputeAutoPilotControl()
     {
-
         float area = m_AeroModel.WingArea;
         float dynamicPressure = m_AeroModel.DynPressure;
 
         // Lift Force ~= 2pi * AoA * dynP * area
         float desiredAngleOfAttack = m_accelerationCmd.magnitude * m_body.mass / area / dynamicPressure / (2 * Mathf.PI);
-        float attackLimited = Mathf.Min(desiredAngleOfAttack * Mathf.Rad2Deg, m_angleOfAttackLimit);
+        float attackLimited = Mathf.Min(desiredAngleOfAttack * Mathf.Rad2Deg, m_angleOfAttackLimit_deg);
 
-        // what even is this bit?
-        Vector3 turnDir = Vector3.Cross(m_velocity, m_accelerationCmd).normalized;
-        Vector3 desiredForward = Quaternion.AngleAxis(attackLimited, turnDir) * m_velocity.normalized;
-        Vector3 angle = -Vector3.Cross(desiredForward, m_body.transform.forward);
-        float phi = Mathf.Asin(angle.magnitude);
+        // Compute the desired forward direction to achieve the AoA
+        Vector3 turnAxis = Vector3.Cross(m_velocity, m_accelerationCmd).normalized;
+        Vector3 desiredForward = Quaternion.AngleAxis(attackLimited, turnAxis) * m_velocity.normalized;
 
+        // Calculate the error angle from this new desiredForward
+        Vector3 misalignmentAxis = -Vector3.Cross(desiredForward, m_body.transform.forward);
+        float misalignmentAngle = Mathf.Asin(misalignmentAxis.magnitude);
+
+        Quaternion worldToBodyRotation = Quaternion.Inverse(transform.rotation);
+
+        Vector3 alignmentError_local = worldToBodyRotation * misalignmentAxis.normalized * misalignmentAngle;  // z component should be zero      
+        
         // get the error rate to calculate the control for this time step
-        Vector3 error = phi * angle.normalized / 2f / Mathf.PI;
-        Vector3 errorRate = error / m_timeConstant; // Slew control to moderate the error rate
-        Vector3 control = m_pidController.PID(errorRate);
+        Vector3 alignmentErrorRate_local = alignmentError_local / m_timeConstant; // Slew control to moderate the error rate
+        Vector3 attitudeControl = Vector3.zero;
+        attitudeControl.x = m_vertPIDController.PID(alignmentErrorRate_local.x/2f/Mathf.PI);
+        attitudeControl.y = m_horzPIDController.PID(alignmentErrorRate_local.y/2f/Mathf.PI);
 
-        return control;
+        // skip doing roll control for now I don't need it -- need a better method
+        //Vector3 angularVelocity_local = worldToBodyRotation * m_body.angularVelocity;
+        //attitudeControl.z = m_rollPIDController.PID(-angularVelocity_local.z/2f/Mathf.PI);
+
+        // could also add a cascade PID control: sets a desired rate from the error in outer PID and an inner PID controls the error rate
+
+        return attitudeControl;
     }
 
-    Vector3 GravityTurnCommand()
+    Vector3 CommandGravityTurn()
     {
-
+        // this method is not great. It scales with the control gains so we will spin out if the attitude gain is too high
         Vector3 rotationDir = Vector3.Cross(m_velocity, RelativePosition).normalized;
         Vector3 accelerationCmd = Vector3.Cross(rotationDir, m_velocity).normalized * 9.8f;
+        //accelerationCmd += -Physics.gravity;
         return accelerationCmd;
         
     }
 
-    Vector3 PursuitCommand()
+    Vector3 CommandPursuit()
     {
-        Vector3 accelerationCmd = PureProNav(RelativePosition, RelativeVelocity, Gain);// + Vector3.up * 9.8f * gain/2;
+        Vector3 accelerationCmd = PureProNav(RelativePosition, RelativeVelocity, NavGain);// + Vector3.up * 9.8f * gain/2;
         accelerationCmd += -Physics.gravity;
         return accelerationCmd;
 
@@ -113,11 +138,11 @@ public class AutoPilotController : MonoBehaviour
 
     Vector3 PureProNav(Vector3 relPos, Vector3 relVel, float gain)
     {
-        Vector3 LoSRate = Vector3.Cross(relPos, relVel) / (relPos.magnitude * relPos.magnitude);
+        Vector3 LOSRate = Vector3.Cross(relPos, relVel) / (relPos.magnitude * relPos.magnitude);
 
         float speedRatio = relVel.magnitude / m_velocity.magnitude;
 
-        Vector3 accelerationCmd = -gain * speedRatio * Vector3.Cross(m_velocity, LoSRate);
+        Vector3 accelerationCmd = -gain * speedRatio * Vector3.Cross(m_velocity, LOSRate);
 
         return accelerationCmd;
     }

--- a/Assets/Scripts/AutoPilotController.cs
+++ b/Assets/Scripts/AutoPilotController.cs
@@ -9,7 +9,7 @@ public class AutoPilotController : MonoBehaviour
     [SerializeField]
     private float m_timeConstant = 0.8f;
     [SerializeField]
-    private float m_angleOfAttackLimit_deg = 10f; // degrees
+    private float m_angleOfAttackLimit_deg;
     [Header("Vertical Pitch PID")]
     [SerializeField] private PIDController m_vertPIDController;
     [Header("Horizontal Pitch PID")]
@@ -51,6 +51,11 @@ public class AutoPilotController : MonoBehaviour
 
         m_AeroModel = GetComponent<AerodynamicsModel>();
         m_body = GetComponent<Rigidbody>();
+    }
+
+    void Start()
+    {
+        m_angleOfAttackLimit_deg = m_AeroModel.StallAoA_deg - 2f;
     }
 
     void Update()

--- a/Assets/Scripts/Missile.cs
+++ b/Assets/Scripts/Missile.cs
@@ -77,23 +77,11 @@ public class Missile : MonoBehaviour
         {
             Explode();
         }
+
+        Vector3 attitudeControl = m_AutoPilot.ComputeAutoPilotControl();
+
+        m_AeroModel.SetAttitudeControl(attitudeControl);
     }
-
-    void FixedUpdate()
-    {
-        Vector3 control = m_AutoPilot.GetControl();
-
-        Vector3 torque = m_AeroModel.GenerateControlTorque(control);
-
-        Vector3 aeroForces = m_AeroModel.GenerateAeroForces();
-        m_body.AddForce(aeroForces);
-
-        if (torque.magnitude > 0.001)
-        {
-            m_body.AddTorque(torque);
-        }
-    }
-
 
     private void Explode()
     {

--- a/Assets/Scripts/Missile.cs
+++ b/Assets/Scripts/Missile.cs
@@ -18,13 +18,13 @@ public class Missile : MonoBehaviour
 
 
     [SerializeField]
-    private ParticleSystem explosionParticle;
+    private ParticleSystem m_explosionParticle;
     [SerializeField]
-    private AudioClip explosionSound;
-    private AudioSource missileAudio;
-    private IEnumerator thrustLooper;
+    private AudioClip m_explosionSound;
+    private AudioSource m_missileAudio;
+    private IEnumerator m_thrustLooper;
     [SerializeField]
-    private AudioClip thrustSound;
+    private AudioClip m_thrustSound;
 
     private AerodynamicsModel m_AeroModel;
     private AutoPilotController m_AutoPilot;
@@ -43,25 +43,24 @@ public class Missile : MonoBehaviour
     void Awake()
     {
         m_body = GetComponent<Rigidbody>();
-        missileAudio = GetComponent<AudioSource>();
+        m_missileAudio = GetComponent<AudioSource>();
         m_AeroModel = GetComponent<AerodynamicsModel>();
         m_AutoPilot = GetComponent<AutoPilotController>();
     }
 
     void Start()
-    {
-        
+    {      
         m_body.centerOfMass = m_missileCOM.transform.localPosition;
         m_body.AddForce(Vector3.up * m_launchSpeed, ForceMode.VelocityChange);
         
-        thrustLooper = LoopAudio(1f);
-        missileAudio.clip = thrustSound;
+        m_thrustLooper = LoopAudio(1f);
+        m_missileAudio.clip = m_thrustSound;
 
         m_AutoPilot.Target = m_target;
 
-        StartCoroutine(thrustLooper);
+        StartCoroutine(m_thrustLooper);
 
-        explosionParticle.Stop();
+        m_explosionParticle.Stop();
 
     }
 
@@ -89,10 +88,10 @@ public class Missile : MonoBehaviour
         {
             Damage();
             m_exploded = true;
-            StopCoroutine(thrustLooper);
-            explosionParticle.Play();
-            missileAudio.Stop();
-            missileAudio.PlayOneShot(explosionSound, 0.2f);
+            StopCoroutine(m_thrustLooper);
+            m_explosionParticle.Play();
+            m_missileAudio.Stop();
+            m_missileAudio.PlayOneShot(m_explosionSound, 0.2f);
             Destroy(gameObject.transform.GetChild(0).gameObject);
             StartCoroutine(Explosion());
         }
@@ -136,8 +135,8 @@ public class Missile : MonoBehaviour
         while (true)
         {
             float mywait = Mathf.Max(0.1f, Mathf.Min(1f, m_AutoPilot.RelativePosition.magnitude / 1000f)) * waitTime;
-            missileAudio.time = 0f;
-            missileAudio.Play();
+            m_missileAudio.time = 0f;
+            m_missileAudio.Play();
             yield return new WaitForSeconds(mywait);
         }
 

--- a/Assets/Scripts/MissileAeroModel.cs
+++ b/Assets/Scripts/MissileAeroModel.cs
@@ -1,0 +1,40 @@
+using UnityEngine;
+
+public class MissileAeroModel : AerodynamicsModel
+{
+    [SerializeField]
+    private float m_finArea = 0.1f;
+    [SerializeField]
+    private float m_finMaxDeflect_deg = 40f;
+    [SerializeField]
+    private float m_tailToCMDistance = 2.5f;
+    [SerializeField]
+    private float m_missileRadius = 0.3f;
+    [SerializeField]
+    private float m_wingArea = 1f; // override default
+    public override float WingArea { get { return m_wingArea; } }
+
+    override public Vector3 CalculateLocalAttitudeMoment(Vector3 attitudeControl)
+    {
+
+        if (attitudeControl.magnitude > 1)
+        {
+            attitudeControl = attitudeControl.normalized;
+        }
+
+        float liftCoefficient = 2f * Mathf.PI * m_finMaxDeflect_deg * Mathf.Deg2Rad; //* Mathf.Deg2Rad;
+
+        float maxTorque = 4 * DynPressure * liftCoefficient * m_finArea * m_tailToCMDistance;
+        float maxRollTorque = 4 * DynPressure * liftCoefficient * m_finArea * m_missileRadius;
+        Vector3 attitudeMoment_local = Vector3.zero;
+        attitudeMoment_local.x = attitudeControl.x * maxTorque;
+        attitudeMoment_local.y = attitudeControl.y * maxTorque;
+        attitudeMoment_local.z = attitudeControl.z * maxRollTorque;
+
+        return attitudeMoment_local; // in local frame
+
+    }
+
+
+
+}

--- a/Assets/Scripts/MissileAeroModel.cs.meta
+++ b/Assets/Scripts/MissileAeroModel.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cd57d3d5be4a5a043ac7f54f0fc4f18c

--- a/Assets/Scripts/PIDController.cs
+++ b/Assets/Scripts/PIDController.cs
@@ -9,9 +9,9 @@ public class PIDController
     private float m_errorLast;
     //private Vector3 m_errorAccumulator = Vector3.zero;
     private float m_errorAccumulator;
-    [SerializeField, Min(0)] private float pGain = 1f;
+    [SerializeField, Min(0)] private float pGain = 6f;
     [SerializeField, Min(0)] private float iGain = 0.001f;
-    [SerializeField, Min(0)] private float dGain = 0.2f;
+    [SerializeField, Min(0)] private float dGain = 0.5f;
     public float PGain { get => pGain; set { if (value > 0) { pGain = value; } } }
     public float IGain { get => iGain; set { if (value > 0) { iGain = value; } } }
     public float DGain { get => dGain; set { if (value > 0) { dGain = value; } } }

--- a/Assets/Scripts/PIDController.cs
+++ b/Assets/Scripts/PIDController.cs
@@ -1,4 +1,5 @@
 using System;
+using Unity.VisualScripting;
 using UnityEngine;
 
 [Serializable]
@@ -8,12 +9,12 @@ public class PIDController
     private float m_errorLast;
     //private Vector3 m_errorAccumulator = Vector3.zero;
     private float m_errorAccumulator;
-    [SerializeField] private float pGain = 1f;
-    [SerializeField] private float iGain = 0.001f;
-    [SerializeField] private float dGain = 0.2f;
-    public float PGain { get => pGain; set => pGain = value; }
-    public float IGain { get => iGain; set => iGain = value; }
-    public float DGain { get => dGain; set => dGain = value; }
+    [SerializeField, Min(0)] private float pGain = 1f;
+    [SerializeField, Min(0)] private float iGain = 0.001f;
+    [SerializeField, Min(0)] private float dGain = 0.2f;
+    public float PGain { get => pGain; set { if (value > 0) { pGain = value; } } }
+    public float IGain { get => iGain; set { if (value > 0) { iGain = value; } } }
+    public float DGain { get => dGain; set { if (value > 0) { dGain = value; } } }
 
     public PIDController() { }
     public PIDController(float p, float i, float d)

--- a/Assets/Scripts/PIDController.cs
+++ b/Assets/Scripts/PIDController.cs
@@ -1,42 +1,57 @@
+using System;
 using UnityEngine;
 
-public class PIDController : MonoBehaviour
+[Serializable]
+public class PIDController
 {
-    private Vector3 m_errorLast = Vector3.zero;
-    private Vector3 m_errorAccumulator = Vector3.zero;
-    [SerializeField]
-    private float pGain = 1f;
-    [SerializeField]
-    private float iGain = 0.001f;
-    [SerializeField]
-    private float dGain = 0.2f;
+    //private Vector3 m_errorLast = Vector3.zero;
+    private float m_errorLast;
+    //private Vector3 m_errorAccumulator = Vector3.zero;
+    private float m_errorAccumulator;
+    [SerializeField] private float pGain = 1f;
+    [SerializeField] private float iGain = 0.001f;
+    [SerializeField] private float dGain = 0.2f;
+    public float PGain { get => pGain; set => pGain = value; }
+    public float IGain { get => iGain; set => iGain = value; }
+    public float DGain { get => dGain; set => dGain = value; }
 
-    void Start()
+    public PIDController() { }
+    public PIDController(float p, float i, float d)
     {
-
+        pGain = p;
+        iGain = i;
+        dGain = d;
     }
-
-    public Vector3 PID(Vector3 error)
+    public float PID(float error)
     {
-        Vector3 dError = (error - m_errorLast) / Time.fixedDeltaTime;
-        Vector3 iError = m_errorAccumulator + error * Time.fixedDeltaTime;
+        float dError = (error - m_errorLast) / Time.fixedDeltaTime;
+        float iError = m_errorAccumulator + error * Time.fixedDeltaTime;
 
-        if (m_errorLast == Vector3.zero)
+        if (m_errorLast == 0)
         {
-            dError = Vector3.zero;
+            dError = 0;
         }
 
-        Vector3 PID = pGain * error + dGain * dError + iGain * iError;
+        float PID = pGain * error + dGain * dError + iGain * iError;
 
-        if (PID.magnitude > 1)
+        if (PID > 1)
         {
-            PID = PID.normalized;
+            PID = 1;
+        }
+        else if (PID < -1)
+        {
+            PID = -1;
         }
 
         m_errorLast = error;
         m_errorAccumulator += error;
 
-
         return PID;
+    }
+
+    public void Reset()
+    {
+        m_errorLast = 0;
+        m_errorAccumulator = 0;
     }
 }

--- a/ProjectSettings/SceneTemplateSettings.json
+++ b/ProjectSettings/SceneTemplateSettings.json
@@ -4,164 +4,123 @@
         {
             "userAdded": false,
             "type": "UnityEngine.AnimationClip",
-            "ignore": false,
-            "defaultInstantiationMode": 0,
-            "supportsModification": true
+            "defaultInstantiationMode": 0
         },
         {
             "userAdded": false,
             "type": "UnityEditor.Animations.AnimatorController",
-            "ignore": false,
-            "defaultInstantiationMode": 0,
-            "supportsModification": true
+            "defaultInstantiationMode": 0
         },
         {
             "userAdded": false,
             "type": "UnityEngine.AnimatorOverrideController",
-            "ignore": false,
-            "defaultInstantiationMode": 0,
-            "supportsModification": true
+            "defaultInstantiationMode": 0
         },
         {
             "userAdded": false,
             "type": "UnityEditor.Audio.AudioMixerController",
-            "ignore": false,
-            "defaultInstantiationMode": 0,
-            "supportsModification": true
+            "defaultInstantiationMode": 0
         },
         {
             "userAdded": false,
             "type": "UnityEngine.ComputeShader",
-            "ignore": true,
-            "defaultInstantiationMode": 1,
-            "supportsModification": true
+            "defaultInstantiationMode": 1
         },
         {
             "userAdded": false,
             "type": "UnityEngine.Cubemap",
-            "ignore": false,
-            "defaultInstantiationMode": 0,
-            "supportsModification": true
+            "defaultInstantiationMode": 0
         },
         {
             "userAdded": false,
             "type": "UnityEngine.GameObject",
-            "ignore": false,
-            "defaultInstantiationMode": 0,
-            "supportsModification": true
+            "defaultInstantiationMode": 0
         },
         {
             "userAdded": false,
             "type": "UnityEditor.LightingDataAsset",
-            "ignore": false,
-            "defaultInstantiationMode": 0,
-            "supportsModification": false
+            "defaultInstantiationMode": 0
         },
         {
             "userAdded": false,
             "type": "UnityEngine.LightingSettings",
-            "ignore": false,
-            "defaultInstantiationMode": 0,
-            "supportsModification": true
+            "defaultInstantiationMode": 0
         },
         {
             "userAdded": false,
             "type": "UnityEngine.Material",
-            "ignore": false,
-            "defaultInstantiationMode": 0,
-            "supportsModification": true
+            "defaultInstantiationMode": 0
         },
         {
             "userAdded": false,
             "type": "UnityEditor.MonoScript",
-            "ignore": true,
-            "defaultInstantiationMode": 1,
-            "supportsModification": true
+            "defaultInstantiationMode": 1
         },
         {
             "userAdded": false,
             "type": "UnityEngine.PhysicMaterial",
-            "ignore": false,
-            "defaultInstantiationMode": 0,
-            "supportsModification": true
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.PhysicsMaterial",
+            "defaultInstantiationMode": 0
         },
         {
             "userAdded": false,
             "type": "UnityEngine.PhysicsMaterial2D",
-            "ignore": false,
-            "defaultInstantiationMode": 0,
-            "supportsModification": true
+            "defaultInstantiationMode": 0
         },
         {
             "userAdded": false,
             "type": "UnityEngine.Rendering.PostProcessing.PostProcessProfile",
-            "ignore": false,
-            "defaultInstantiationMode": 0,
-            "supportsModification": true
+            "defaultInstantiationMode": 0
         },
         {
             "userAdded": false,
             "type": "UnityEngine.Rendering.PostProcessing.PostProcessResources",
-            "ignore": false,
-            "defaultInstantiationMode": 0,
-            "supportsModification": true
+            "defaultInstantiationMode": 0
         },
         {
             "userAdded": false,
             "type": "UnityEngine.Rendering.VolumeProfile",
-            "ignore": false,
-            "defaultInstantiationMode": 0,
-            "supportsModification": true
+            "defaultInstantiationMode": 0
         },
         {
             "userAdded": false,
             "type": "UnityEditor.SceneAsset",
-            "ignore": false,
-            "defaultInstantiationMode": 0,
-            "supportsModification": false
+            "defaultInstantiationMode": 0
         },
         {
             "userAdded": false,
             "type": "UnityEngine.Shader",
-            "ignore": true,
-            "defaultInstantiationMode": 1,
-            "supportsModification": true
+            "defaultInstantiationMode": 1
         },
         {
             "userAdded": false,
             "type": "UnityEngine.ShaderVariantCollection",
-            "ignore": true,
-            "defaultInstantiationMode": 1,
-            "supportsModification": true
+            "defaultInstantiationMode": 1
         },
         {
             "userAdded": false,
             "type": "UnityEngine.Texture",
-            "ignore": false,
-            "defaultInstantiationMode": 0,
-            "supportsModification": true
+            "defaultInstantiationMode": 0
         },
         {
             "userAdded": false,
             "type": "UnityEngine.Texture2D",
-            "ignore": false,
-            "defaultInstantiationMode": 0,
-            "supportsModification": true
+            "defaultInstantiationMode": 0
         },
         {
             "userAdded": false,
             "type": "UnityEngine.Timeline.TimelineAsset",
-            "ignore": false,
-            "defaultInstantiationMode": 0,
-            "supportsModification": true
+            "defaultInstantiationMode": 0
         }
     ],
     "defaultDependencyTypeInfo": {
         "userAdded": false,
         "type": "<default_scene_template_dependencies>",
-        "ignore": false,
-        "defaultInstantiationMode": 1,
-        "supportsModification": true
+        "defaultInstantiationMode": 1
     },
     "newSceneOverride": 0
 }


### PR DESCRIPTION
Multiple changes to make the Aero model abstract. The PID controller interface was changed to allow for independent axis of control (i.e. yaw, pitch, roll) by making it not a monobehavior but instead instanced in the AutoPilot. PID is also works on a float, i.e. a single component. The Autopilot does the control calculations now in the local frame which is reflected in the missile aero model. There were many naming changes for better understandability and also some corrections to the torque (now attitude moment) calculations with PID gain adjustments.

The Aero model was then abstracted into a base which applies the lift+drag forces as usual and calls an abstract CalculateLocalAttitudeMoment with a vector3 control argument which is implemented by the MissileAeroModel concrete subclass. The subclass also defines the (adjustable) aero surface properties such as the area and distance from the CoM.